### PR TITLE
Adding constant for all oncho measures

### DIFF
--- a/endgame_postprocessing/model_wrappers/constants.py
+++ b/endgame_postprocessing/model_wrappers/constants.py
@@ -27,3 +27,9 @@ COUNTRY_THRESHOLD_RENAME_MAP = {
 # Africa Level Params
 AFRICA_SUMMARY_MEASURES = ["prevalence"]
 AFRICA_LVL_GROUP_COLUMNS = ["scenario", "year_id", "age_start", "age_end", "measure"]
+
+# Disease Specifics
+ONCHO_MEASURES = ["APOD", "Atrophy", "Blindness", "CPOD", "Depigmentation", "HangingGroin",
+                  "OAE_prevalence", "RSDComplex", "RSDSimple", "SevereItching", "VisualImpairment",
+                  "intensity", "mean_worm_burden", "number", "pnc", "prevalence"
+]

--- a/endgame_postprocessing/model_wrappers/oncho/testRun.py
+++ b/endgame_postprocessing/model_wrappers/oncho/testRun.py
@@ -32,7 +32,9 @@ with tqdm(total=1, desc="Post-processing Scenarios") as pbar:
             iuName=file_info.iu,
             prevalence_marker_name="prevalence",
             post_processing_start_time=1970,
-            measure_summary_map={"prevalence": measure_summary_float},
+            measure_summary_map={
+            measure: measure_summary_float for measure in constants.ONCHO_MEASURES
+            },
         ).to_csv(
             "post-processed-outputs/oncho/" + file_info.scenario + "_" +
             file_info.iu + "post_processed.csv"


### PR DESCRIPTION
As the title says, adding a constant to include all the oncho measures we would want to post-process. Also edits the oncho testRun.py file to use said constant.

Tested locally both with oncho/testRun.py and `poetry run pytest`