### PR TITLE
Combine ages from IHME output

### DIFF
--- a/endgame_postprocessing/model_wrappers/sch/testRun.py
+++ b/endgame_postprocessing/model_wrappers/sch/testRun.py
@@ -1,0 +1,23 @@
+import numpy as np
+import pandas as pd
+
+
+def first_row(df):
+    return df.iloc[0]
+
+
+def recombine_ages(raw_data: pd.DataFrame):
+    each_intensity_measure = [
+        df for _, df in raw_data.groupby(["Time", "intensity", "measure"])
+    ]
+    aggregate_functions = {c: first_row for c in raw_data.columns}
+    aggregate_functions["draw_1"] = np.sum
+    aggregate_functions["age_start"] = np.min
+    aggregate_functions["age_end"] = np.max
+
+    aggregated_by_group = [
+        measure_values.aggregate(aggregate_functions)
+        for measure_values in each_intensity_measure
+    ]
+
+    return pd.concat(aggregated_by_group, axis=1).T

--- a/tests/model_wrappers/sch/test_testRun.py
+++ b/tests/model_wrappers/sch/test_testRun.py
@@ -1,0 +1,50 @@
+import pandas as pd
+import pandas.testing as pdt
+from endgame_postprocessing.model_wrappers.sch.testRun import recombine_ages
+
+
+def test_recombine_ages_unique_measures_unaffected():
+    input = pd.DataFrame(
+        {
+            "Time": [0, 1],
+            "age_start": [0, 0],
+            "age_end": [1, 1],
+            "intensity": ["normal", "high"],
+            "measure": ["prevalance", "prevalance"],
+            "draw_1": [3, 1],
+        }
+    )
+
+    output = recombine_ages(input)
+    # TODO: why is dtype wrong
+    pdt.assert_frame_equal(output, input, check_dtype=False)
+
+
+def test_recombine_ages_two_age_groups_summed():
+    input = pd.DataFrame(
+        {
+            "Time": [0, 0],
+            "intensity": ["normal", "normal"],
+            "age_start": [0, 1],
+            "age_end": [1, 2],
+            "measure": ["prevalance", "prevalance"],
+            "draw_1": [3, 1],
+        }
+    )
+
+    output = recombine_ages(input)
+    pdt.assert_frame_equal(
+        output,
+        pd.DataFrame(
+            {
+                "Time": [0],
+                "age_start": [0],
+                "age_end": [2],
+                "intensity": ["normal"],
+                "measure": ["prevalance"],
+                "draw_1": [4],
+            }
+        ),
+        check_dtype=False,
+        check_like=True,
+    )


### PR DESCRIPTION
WIP, still need to:

 - [ ] Combine all 200 runs into single csv (if not already done by Igor)
 - [ ] Work out how to combine prevalance numbers - they appear to be percentage of people in that age group, but you can't just aggregate that together without knowing weight of each group. 
 - [ ] Add measure - whether prevalence (in 5-14 y.o.) of medium and high intensity infections is below 2%,
 - [ ] Add measure - whether an IU has passed a survey
 - [ ] Add measure - whether an IU has achieved EPHP 
 - [ ] Take the stratification of intensity into the measure column
 - [ ] Actually put together into a full script like LF and Epioncho 