### PR TITLE
Add ability to remap IUs based on a mapping file

### DIFF
--- a/tests/model_wrappers/sch/test_run_sch.py
+++ b/tests/model_wrappers/sch/test_run_sch.py
@@ -4,6 +4,8 @@ from endgame_postprocessing.model_wrappers.sch.run_sch import (
     combine_many_worms,
     get_sth_flat,
     probability_any_worm,
+    read_remapping_file,
+    remap_old_ius_to_new_ius,
 )
 from endgame_postprocessing.post_processing.dataclasses import CustomFileInfo
 
@@ -106,4 +108,97 @@ def test_flat_walk(fs):
             iu="AGO02049",
             file_path="foo/ntdmc-AGO02049-hookworm-group_001-scenario_2a-group_001-200_simulations.csv",
         )
+    ]
+
+
+def test_read_remapping_file():
+    input = pd.DataFrame(
+        {
+            "IU_CODE": ["AAA0", "AAA0", "BBB0"],
+            "ADMIN0ISO3": ["AAA", "AAA", "BBB"],
+            "ESPEN_IU_ID": [1.0, 2.0, 1.0],
+        }
+    )
+    output = read_remapping_file(input)
+    assert output == {"AAA0": ["AAA1", "AAA2"], "BBB0": ["BBB1"]}
+
+
+def test_read_remapping_file_with_nan():
+    input = pd.DataFrame(
+        {
+            "IU_CODE": ["AAA0"],
+            "ADMIN0ISO3": ["AAA"],
+            "ESPEN_IU_ID": [pd.NA],
+        }
+    )
+    output = read_remapping_file(input)
+    assert output == {}
+
+
+def test_read_remapping_file_with_nan_in_irrelevant_column():
+    input = pd.DataFrame(
+        {
+            "IU_CODE": ["AAA0"],
+            "ADMIN0ISO3": ["AAA"],
+            "ESPEN_IU_ID": [1.0],
+            "another_column": [pd.NA],
+        }
+    )
+    output = read_remapping_file(input)
+    assert output == {"AAA0": ["AAA1"]}
+
+
+def test_remap_old_ius_to_new_ius_in_mapping():
+    remapping = {"A": ["A1", "A2"], "B": ["B"]}
+    file = CustomFileInfo(
+        scenario="s",
+        scenario_index=0,
+        total_scenarios=1,
+        country="A",
+        iu="A",
+        file_path="A.csv",
+    )
+
+    result = remap_old_ius_to_new_ius(file, remapping)
+    assert result == [
+        CustomFileInfo(
+            scenario="s",
+            scenario_index=0,
+            total_scenarios=1,
+            country="A",
+            iu="A1",
+            file_path="A.csv",
+        ),
+        CustomFileInfo(
+            scenario="s",
+            scenario_index=0,
+            total_scenarios=1,
+            country="A",
+            iu="A2",
+            file_path="A.csv",
+        ),
+    ]
+
+
+def test_remap_old_ius_to_new_ius_not_in_mapping():
+    remapping = {"B": ["B"]}
+    file = CustomFileInfo(
+        scenario="s",
+        scenario_index=0,
+        total_scenarios=1,
+        country="A",
+        iu="A",
+        file_path="A.csv",
+    )
+
+    result = remap_old_ius_to_new_ius(file, remapping)
+    assert result == [
+        CustomFileInfo(
+            scenario="s",
+            scenario_index=0,
+            total_scenarios=1,
+            country="A",
+            iu="A",
+            file_path="A.csv",
+        ),
     ]


### PR DESCRIPTION
This allows a remapping file with columns

* IU_CODE
* ADMIN0ISO3
* ESPEN_IU_ID

S.t. If AAA1 remaps to AAA2 and AAA3 then you would have:

```
AAA1, AAA, 2,
AAA1, AAA, 3
```
For example, here is what Paul provided: [missing_ius_added.csv](https://github.com/user-attachments/files/17510424/missing_ius_added.csv)


Put that file in the root directory (next to the meta data file) called `iu_remapping.csv` then when it canonicalises, it will instead of spitting out canonical_AAA1.csv, will instead spit out identical `canonical_AAA2.csv`, `canonical_AAA3.csv`. 

**TODO: it doesn't fix the IU_CODE _inside_ the spreadsheet - see TODO in code.**

This partially addresses https://github.com/NTD-Modelling-Consortium/endgame-project/issues/152 though still requires something to be done about the IUs that are missing and not in Pauls remapping file (e.g. something like #18)