### PR TITLE
Remove non-simulated IUs from the meta data file

### DIFF
--- a/endgame_postprocessing/post_processing/iu_data.py
+++ b/endgame_postprocessing/post_processing/iu_data.py
@@ -26,13 +26,22 @@ def _get_capitalised_disease(disease: Disease):
     raise Exception(f"Invalid disease {disease}")
 
 
-def preprocess_iu_meta_data(input_data: pd.DataFrame):
+def remove_non_simulated_ius(input_data: pd.DataFrame, simulated_IUs: list[str]):
+    return input_data.loc[input_data.IU_CODE.isin(simulated_IUs)]
+
+
+def preprocess_iu_meta_data(input_data: pd.DataFrame, simulated_IUs: list[str]):
     deduped_input_data = input_data.drop_duplicates()
     new_iu_code = deduped_input_data.ADMIN0ISO3 + deduped_input_data["IU_ID"].apply(
         lambda id: str.zfill(str(id), 5)
     )
     deduped_input_data.loc[:, "IU_CODE"] = new_iu_code
-    return deduped_input_data
+
+    # We remove non-simualted IUs as the current IU meta data file has mismatched IUs
+    # so we don't really know if the IUs that don't have matching simulations are
+    # actually simulated with a different ID, so for now we just drop them
+    only_simulated_ius = remove_non_simulated_ius(deduped_input_data, simulated_IUs)
+    return only_simulated_ius
 
 
 class IUSelectionCriteria(Enum):

--- a/endgame_postprocessing/post_processing/pipeline.py
+++ b/endgame_postprocessing/post_processing/pipeline.py
@@ -153,7 +153,8 @@ def pipeline(input_dir, working_directory, pipeline_config: PipelineConfig):
 
     iu_meta_data = IUData(
         iu_data.preprocess_iu_meta_data(
-            pd.read_csv(f"{input_dir}/PopulationMetadatafile.csv")
+            pd.read_csv(f"{input_dir}/PopulationMetadatafile.csv"),
+            simulated_IUs=all_ius,
         ),
         pipeline_config.disease,
         iu_selection_criteria=IUSelectionCriteria.SIMULATED_IUS,

--- a/endgame_postprocessing/post_processing/pipeline.py
+++ b/endgame_postprocessing/post_processing/pipeline.py
@@ -120,7 +120,12 @@ def africa_composite(working_directory, iu_meta_data):
     )
 
 
-def country_aggregate(country_composite, iu_lvl_data, country_code, iu_meta_data):
+def country_aggregate(
+    country_composite: pd.DataFrame,
+    iu_lvl_data: pd.DataFrame,
+    country_code: str,
+    iu_meta_data: IUData,
+):
     country_statistical_aggregates = single_country_aggregate(country_composite)
     country_iu_summary_aggregates = country_lvl_aggregate(
         iu_lvl_data,

--- a/tests/post_processing/test_iu_data.py
+++ b/tests/post_processing/test_iu_data.py
@@ -6,6 +6,7 @@ from endgame_postprocessing.post_processing.iu_data import (
     IUSelectionCriteria,
     InvalidIUDataFile,
     preprocess_iu_meta_data,
+    remove_non_simulated_ius,
 )
 
 from endgame_postprocessing.post_processing.disease import Disease
@@ -290,7 +291,34 @@ def test_preprocess_iu_meta_data_contains_duplicate_and_valid_id():
                 "IU_CODE": ["AAA0000000001"] * 2,
                 "IU_ID": [1] * 2,
             }
-        )
+        ),
+        simulated_IUs=["AAA00001"],
+    )
+
+    pdt.assert_frame_equal(
+        preprocessed_input,
+        pd.DataFrame(
+            {
+                "ADMIN0ISO3": ["AAA"],
+                "Priority_Population_LF": [100],
+                "IU_CODE": ["AAA00001"],
+                "IU_ID": [1],
+            }
+        ),
+    )
+
+
+def test_preprocess_iu_meta_data_removes_non_simulated_ius():
+    preprocessed_input = preprocess_iu_meta_data(
+        pd.DataFrame(
+            {
+                "ADMIN0ISO3": ["AAA"] * 2,
+                "Priority_Population_LF": [100] * 2,
+                "IU_CODE": ["AAA0000000001", "AAA0000000002"],
+                "IU_ID": [1, 2],
+            }
+        ),
+        simulated_IUs=["AAA00001"],
     )
 
     pdt.assert_frame_equal(
@@ -321,4 +349,14 @@ def test_simulated_ius_includes_simulated_iu():
             simulated_IUs=["AAA00001", "BBB00001"],
         ).get_priority_population_for_africa()
         == 500
+    )
+
+
+def test_remove_nonsimualted_ius():
+    input_data = pd.DataFrame(
+        {"IU_CODE": ["AAA123", "AAA234"], "AnotherColumn": [1, 2]}
+    )
+    result = remove_non_simulated_ius(input_data, simulated_IUs=["AAA123"])
+    pdt.assert_frame_equal(
+        result, pd.DataFrame({"IU_CODE": ["AAA123"], "AnotherColumn": [1]})
     )


### PR DESCRIPTION
Whilst the IU meta data file contains IUs that probably map onto existing IUs, but we don't know how, to ensure sensible output, in the meta data clean up step we remove _all_ IUs that are not simulated, creating the false reality of simulated IUs are _all_ the IUs that exist. 