### PR TITLE
Updating any worm combinations for SCH/STH

### DIFF
--- a/endgame_postprocessing/model_wrappers/sch/README.md
+++ b/endgame_postprocessing/model_wrappers/sch/README.md
@@ -14,6 +14,7 @@ import endgame_postprocessing.model_wrappers.sch.run_sch as run_sch
 
 input_dir = # TODO
 # Collect all of the worm directories that are in the input_dir
+# Note: The first worm directory in the list should contain files for all IUs across the worms
 worm_directories = next(os.walk(input_dir))[1]
 run_sch.run_sth_postprocessing_pipeline(
     input_dir,

--- a/endgame_postprocessing/model_wrappers/sch/README.md
+++ b/endgame_postprocessing/model_wrappers/sch/README.md
@@ -55,6 +55,7 @@ The SCH pipeline can also create an "any worm" result, or a single worm result.
 Unlike STH, the SCH worm structure is differeny by worm. Haematobium is simulated for for all IUs, however mansoni is split by high or low burden. As such, we need to explicitly state the folder order for the pipeline to properly process the data. 
 
 In this case, the "any worm" functionality will expect that an IU that is in haematobium will appear once in either `mansoni-high-burden` or `mansoni-low-burden`. 
+When combining the prevalence of worms for a given run, we choose the max simulated prevalence between mansoni and haematobium.
 
 ```python
 import endgame_postprocessing.model_wrappers.sch.run_sch as run_sch

--- a/endgame_postprocessing/model_wrappers/sch/run_sch.py
+++ b/endgame_postprocessing/model_wrappers/sch/run_sch.py
@@ -71,7 +71,7 @@ def canoncialise_single_result(file_info, warning_if_no_file=False):
     except FileNotFoundError:
         if warning_if_no_file:
             warnings.warn(
-                f"File {file_info.file_path} not found, and `warning_if_no_file` is set to False"
+                f"File {file_info.file_path} not found, and `warning_if_no_file` is set to True"
             )
             return pd.DataFrame()
         raise FileNotFoundError

--- a/tests/model_wrappers/sch/test_run_sch.py
+++ b/tests/model_wrappers/sch/test_run_sch.py
@@ -254,14 +254,14 @@ def test_check_iu_in_all_folders_success_multi_scenario():
         ("worm1", None, "iu1", "scenario2"),
         ("worm2", None, "iu1", "scenario2"),
     ]
-    _check_iu_in_all_folders(worm_iu_infos)
+    _check_iu_in_all_folders(worm_iu_infos, warning_if_no_file=False)
 
 def test_check_iu_in_all_folders_success_single_burden():
     worm_iu_infos = [
         ("worm1", None, "iu1", "scenario1"),
         ("worm2", "low_burden", "iu1", "scenario1"),
     ]
-    _check_iu_in_all_folders(worm_iu_infos)
+    _check_iu_in_all_folders(worm_iu_infos, warning_if_no_file=False)
 
 def test_check_iu_in_all_folders_fail_multi_burden():
     worm_iu_infos = [
@@ -270,16 +270,25 @@ def test_check_iu_in_all_folders_fail_multi_burden():
         ("worm2", "high_burden", "iu1", "scenario1"),
     ]
     with pytest.raises(Exception):
-        _check_iu_in_all_folders(worm_iu_infos)
+        _check_iu_in_all_folders(worm_iu_infos, warning_if_no_file=False)
 
-def test_check_iu_in_all_folders_missing_worm():
+def test_check_iu_in_all_folders_missing_worm_exception():
     worm_iu_infos = [
         ("worm1", None, "iu1", "scenario1"),
         ("worm1", None, "iu2", "scenario1"),
         ("worm2", "high_burden", "iu2", "scenario1"),
     ]
     with pytest.raises(Exception):
-        _check_iu_in_all_folders(worm_iu_infos)
+        _check_iu_in_all_folders(worm_iu_infos, warning_if_no_file=False)
+
+def test_check_iu_in_all_folders_missing_worm_warning():
+    worm_iu_infos = [
+        ("worm1", None, "iu1", "scenario1"),
+        ("worm1", None, "iu2", "scenario1"),
+        ("worm2", "high_burden", "iu2", "scenario1"),
+    ]
+    with pytest.warns():
+        _check_iu_in_all_folders(worm_iu_infos, warning_if_no_file=True)
 
 
 def test_canonicalise_raw_sch_results_all_worm_no_worm_directory():

--- a/tests/model_wrappers/sch/test_run_sch.py
+++ b/tests/model_wrappers/sch/test_run_sch.py
@@ -2,6 +2,7 @@ import pandas as pd
 import pandas.testing as pdt
 import pytest
 from endgame_postprocessing.model_wrappers.sch.run_sch import (
+    canoncialise_single_result,
     combine_many_worms,
     get_sth_flat,
     probability_any_worm,
@@ -9,7 +10,6 @@ from endgame_postprocessing.model_wrappers.sch.run_sch import (
     canonicalise_raw_sch_results,
 )
 from endgame_postprocessing.post_processing.dataclasses import CustomFileInfo
-
 
 def test_probability_any_worm_zero_for_all_worms():
     assert probability_any_worm([0.0, 0.0, 0.0]) == 0.0
@@ -23,7 +23,7 @@ def test_probability_any_worm_half_for_all_worms():
     assert probability_any_worm([0.5, 0.5, 0.5]) == 1.0 - 0.125
 
 
-def test_combine_many_worms():
+def test_combine_many_worms_default_combination():
     first_worm = pd.DataFrame(
         {
             "year": [2010],
@@ -59,7 +59,38 @@ def test_combine_many_worms():
     )
 
 
-def test_combine_many_worms_many_years():
+def test_combine_many_worms_default_combination_empty_df():
+    first_worm = pd.DataFrame(
+        {
+            "year": [2010],
+            "draw_0": [0.5],
+            "draw_1": [1.0],
+        }
+    )
+
+    second_worm = pd.DataFrame(
+        {
+            "year": [2010],
+            "draw_0": [0.5],
+            "draw_1": [0.0],
+        }
+    )
+
+    third_worm = pd.DataFrame()
+
+    pdt.assert_frame_equal(
+        combine_many_worms(first_worm, [second_worm, third_worm]),
+        pd.DataFrame(
+            {
+                "year": [2010],
+                "draw_0": [1 - 0.25],
+                "draw_1": [1.0],
+            }
+        ),
+    )
+
+
+def test_combine_many_worms_default_combination_many_years():
     first_worm = pd.DataFrame(
         {
             "year": [2010, 2011],
@@ -93,6 +124,29 @@ def test_combine_many_worms_many_years():
             }
         ),
     )
+
+
+def test_canoncialise_single_result_no_file_warning():
+    with pytest.warns():
+        canoncialise_single_result(CustomFileInfo(
+            scenario_index=1,
+            total_scenarios=1,
+            scenario="scenario_1",
+            country="TST",
+            iu="TST01234",
+            file_path="random/file.csv",
+        ), warning_if_no_file=True)
+
+def test_canoncialise_single_result_no_file_exception_default():
+    with pytest.raises(Exception):
+        canoncialise_single_result(CustomFileInfo(
+            scenario_index=1,
+            total_scenarios=1,
+            scenario="scenario_1",
+            country="TST",
+            iu="TST01234",
+            file_path="random/file.csv",
+        ))
 
 def test_check_iu_in_all_folders_success_multi_scenario():
     worm_iu_infos = [


### PR DESCRIPTION
As per Deirdre
- For STH, it should be allowed for certain worms to have no data for an IU, and process those with a prevalence of 0
  - We are requiring, however, that at least one worm (which will be denoted as first_worm) should have data for all IUs between the rest of the worms
- For SCH, to combine all worms, it should now use the max prevalence between the two worms, rather than the probabilistic function. 