### PR TITLE
A couple of small type fixes

### DIFF
--- a/endgame_postprocessing/model_wrappers/oncho/testRun.py
+++ b/endgame_postprocessing/model_wrappers/oncho/testRun.py
@@ -69,4 +69,4 @@ def run_postprocessing_pipeline(input_dir: str, output_dir: str):
     pipeline.pipeline(input_dir, output_dir, PipelineConfig(disease=Disease.ONCHO))
 
 if __name__ == "__main__":
-    run_postprocessing_pipeline("local_data/oncho", "local_data/oncho-output", 1)
+    run_postprocessing_pipeline("local_data/oncho", "local_data/oncho-output")

--- a/endgame_postprocessing/post_processing/iu_data.py
+++ b/endgame_postprocessing/post_processing/iu_data.py
@@ -43,7 +43,7 @@ class IUData:
         input_data: pd.DataFrame,
         disease: Disease,
         iu_selection_criteria: IUSelectionCriteria,
-        simulated_IUs: set[str] = None,
+        simulated_IUs: set[str] | None = None,
     ):
         self.disease = disease
         self.input_data = input_data

--- a/endgame_postprocessing/post_processing/measures.py
+++ b/endgame_postprocessing/post_processing/measures.py
@@ -2,7 +2,7 @@ import numpy as np
 from .constants import PERCENTILES_TO_CALC
 
 def _extract_percentiles(
-    percentiles_dict: dict[str : list[int]], percentile_names: list[str]
+    percentiles_dict: dict[str, list[int]], percentile_names: list[str]
 ) -> np.ndarray:
     """
     Helper function to extract percentiles from a dictionary of percentile names to a list of values
@@ -42,7 +42,7 @@ def build_summary(
     age_end: list[int],
     measure_name: list[str],
     mean: list[int],
-    percentiles_dict: dict[str : list[int]],
+    percentiles_dict: dict[str, list[int]],
     percentile_name_order: list[str],
     standard_deviation: list[int],
     median: list[int],


### PR DESCRIPTION
I couldn't get very far as seemingly slicing by columns is not supported in mypy but thought I could avoid throwing away this in any case.

The following is invalid according to mypy:

```
import pandas as pd

df = pd.DataFrame({"col1": [0, 2, 4], "col2": [1, 3, 5]})
sliced_df = df.loc[:, "col2":]
print(sliced_df)
```