### PR TITLE
Add usage README for Oncho

### DIFF
--- a/endgame_postprocessing/model_wrappers/oncho/README.md
+++ b/endgame_postprocessing/model_wrappers/oncho/README.md
@@ -13,9 +13,11 @@ oncho_runner.run_postprocessing_pipeline(
     )
 ```
 
-Here the `input_dir` is the directory of the forward projections. 
+Here the `input_dir` is the directory of the forward projections *and* the 
+Population file - see main [README](../../../README.md#iu-meta-data-file) for the format:
 This is expected to be in the following format:
 
+ - PopulationMetadatafile.csv
  - scenario_1/
    - AAA/
      - AAA00001/


### PR DESCRIPTION
Adds a usage README for running the oncho aggregation pipeline. Covers specifically the fact that the historic data is expected to be flat, but the forward projection should be structured as folders. 