### PR TITLE
Add project setup instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 __pycache__/
 *.DS_Store
+.idea
+*.lock

--- a/README.md
+++ b/README.md
@@ -189,6 +189,16 @@ _Note: because the pct of IUs passing under the threshold is taken over the incl
 ###### Measures
 - **processed_prevalence** - the composite prevalence in Africa. The prevalence for a specific draw is worked out by taking the prevalence for each IU we have results for, multiplying it by its priority population, summing across the IUs, then dividing by the priority population of all included IUs.
 
+## Setup
+
+Setting up the project requires Python (3.10+) and [Poetry](https://python-poetry.org) to be installed.
+
+Once Poetry is installed, the following command can be run at the root of the project directory to install dependencies and finish setup.
+
+```text
+poetry install
+```
+
 
 ##### aggregation_info.json
 


### PR DESCRIPTION
**Motivation**
It is not immediately clear how to setup the project using Poetry or that Poetry is even required for this step. Also, Poetry doesn't come preinstalled with the OS and thus it needs to be installed using the appropriate package manager - `apt` on Ubuntu or `homebrew` on MacOS.


**Changes**
README now contains project setup instructions explaining requirements around Python and Poetry.