### PR TITLE
Bugfix - Glob expression to locate historical data files fixed

### DIFF
--- a/tests/end_to_end/trachoma/known_good_output_historic_missing_iu/aggregation_info.json
+++ b/tests/end_to_end/trachoma/known_good_output_historic_missing_iu/aggregation_info.json
@@ -8,7 +8,7 @@
         {
             "message": "IU 'AAA00001' found in forward projections but not found in history.",
             "file": "model_wrappers/trachoma/run_trach.py",
-            "line": 122
+            "line": 124
         }
     ]
 }

--- a/tests/end_to_end/trachoma/known_good_output_historic_only/aggregation_info.json
+++ b/tests/end_to_end/trachoma/known_good_output_historic_only/aggregation_info.json
@@ -8,7 +8,7 @@
         {
             "message": "IU 'BBB00002' found in history but not in forward projections.",
             "file": "model_wrappers/trachoma/run_trach.py",
-            "line": 126
+            "line": 130
         }
     ]
 }


### PR DESCRIPTION
The glob expression specified for locating historic IU files when using the `get_flat_regex` helper was incorrect. It was looking for `{historic_prefix}_*.csv` which fails when passing a `PrevDataset_Trachoma_` prefix because of the trailing underscore. This PR fixes this by removing the underscore from the glob expression and thus succeeds in both `PrevDataset_Trachoma` and `PrevDataset_Trachoma_` prefixes.