### PR TITLE
Updating cache version as v2 is deprecated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
             poetry config virtualenvs.in-project true --local
         - name: Load cached venv
           id: cached-poetry-dependencies
-          uses: actions/cache@v2
+          uses: actions/cache@v4
           with:
             path: .venv
             key: venv-${{ runner.os }}-${{ hashFiles('**/pyproject.toml') }}


### PR DESCRIPTION
Tests are failing due to `Error: Missing download info for actions/cache@v2`

Issue is that cachev2 is deprecated: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/